### PR TITLE
Add `image` to list of dependencies for pip installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ reverse-engineered the VIP Access application.
 - [qrcode](https://pypi.python.org/pypi/qrcode/5.0.1)
 
 If you have `pip` installed on your system, you can install them with
-`pip install lxml oath PyCrypto qrcode`.
+`pip install lxml oath PyCrypto qrcode image`.
 
 ## Usage
 


### PR DESCRIPTION
Image lib was also needed for to run the qr generation and wasn't installed with rest of dependencies.

Thanks for writing this :).  Having to use the VIP app has bothered me for awhile, so very glad to see an alternative!
