### PR TITLE
Use cryptographically-strong RNG to generate serial numbers, etc.

### DIFF
--- a/vipaccess.py
+++ b/vipaccess.py
@@ -20,7 +20,6 @@ import base64
 import binascii
 import hashlib
 import hmac
-import random
 import string
 import sys
 import time
@@ -29,6 +28,7 @@ import urllib
 import qrcode
 import requests
 from Crypto.Cipher import AES
+from Crypto.Random import random
 from lxml import etree
 from oath import totp
 


### PR DESCRIPTION
This probably doesn't matter, but since a third party is generating
secrets for us, this might help somewhat if their code has a bad RNG but
also mixes in data from the request.