### PR TITLE
Encode request data in utf-8

### DIFF
--- a/vipaccess/utils.py
+++ b/vipaccess/utils.py
@@ -270,7 +270,7 @@ def check_token(token_id, secret):
 def main():
     request = generate_request()
 
-    response = get_provisioning_response(request)
+    response = get_provisioning_response(request.encode('utf-8'))
 
     otp_token = get_token_from_response(response.content)
 


### PR DESCRIPTION
Encoding request data avoids error `TypeError: buf must be a byte string`
